### PR TITLE
URL Cleanup

### DIFF
--- a/pkg/fileutils/abs_test.go
+++ b/pkg/fileutils/abs_test.go
@@ -55,7 +55,7 @@ var _ = Describe("IsAbsFile", func() {
 
 	Context("when the input path is a http URL", func() {
 		BeforeEach(func() {
-			path = "http://projectriff.io"
+			path = "https://projectriff.io"
 		})
 
 		checkAbsolute()
@@ -158,7 +158,7 @@ var _ = Describe("AbsFile", func() {
 
 	Context("when the input path is a http URL", func() {
 		BeforeEach(func() {
-			path = "http://projectriff.io"
+			path = "https://projectriff.io"
 		})
 
 		checkAbsolute()

--- a/pkg/fileutils/copier.go
+++ b/pkg/fileutils/copier.go
@@ -41,7 +41,7 @@ const (
 type Copier interface {
 	/*
 		Copy copies a source file to a destination file. File contents are copied. File mode and permissions
-		(as described in http://golang.org/pkg/os/#FileMode) are copied.
+		(as described in https://golang.org/pkg/os/#FileMode) are copied.
 
 		Directories are copied, along with their contents.
 

--- a/pkg/fileutils/read_test.go
+++ b/pkg/fileutils/read_test.go
@@ -188,7 +188,7 @@ var _ = Describe("ReadUrl", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		resourceUrl, _ := url.Parse(fmt.Sprintf("http://%s/%s", listener.Addr().String(), ""))
+		resourceUrl, _ := url.Parse(fmt.Sprintf("https://%s/%s", listener.Addr().String(), ""))
 
 		result, err := fileutils.ReadUrl(resourceUrl, timeout)
 
@@ -202,7 +202,7 @@ var _ = Describe("ReadUrl", func() {
 			err := test_support.ServeSlow(resourceListener, test_support.HttpResponse{}, 2*timeout)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		resourceUrl, _ := url.Parse(fmt.Sprintf("http://%s/%s", resourceListener.Addr().String(), ""))
+		resourceUrl, _ := url.Parse(fmt.Sprintf("https://%s/%s", resourceListener.Addr().String(), ""))
 
 		_, err := fileutils.ReadUrl(resourceUrl, timeout)
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://%s/%s (UnknownHostException) with 2 occurrences migrated to:  
  https://%s/%s ([https](https://%s/%s) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://golang.org/pkg/os/ with 1 occurrences migrated to:  
  https://golang.org/pkg/os/ ([https](https://golang.org/pkg/os/) result 200).
* http://projectriff.io with 2 occurrences migrated to:  
  https://projectriff.io ([https](https://projectriff.io) result 200).