### PR TITLE
rename default declarative manifest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,11 +30,12 @@ steps:
   - template: ci/fetch-cnab-riff-step.yml
 
   - script: |
-      ./cnab/app/run $(cnabRiffDir)/cnab/app/kab/template.yaml
+      ./cnab/app/run
     workingDirectory: '$(modulePath)'
     displayName: 'run install'
     env:
       CNAB_ACTION: install
+      MANIFEST_FILE: $(cnabRiffDir)/cnab/app/kab/manifest.yaml
       LOG_LEVEL: debug
       TARGET_REGISTRY: registry.kube-system.svc.cluster.local
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   fatsDir: '$(system.defaultWorkingDirectory)/fats'
   fatsRefspec: b65bc2f1d14a80d9d9793e96766bc1d1b19508a4 # projectriff/fats master as of 2019-04-30
   cnabRiffDir: '$(system.defaultWorkingDirectory)/cnab-riff'
-  cnabRiffRefspec: 4a991ce947774a3ac3d000df3987de327a27c875 # projectriff/cnab-riff master as of 2019-04-17
+  cnabRiffRefspec: 6e962bfbbdee1300ee913f06c89c03bb86fd0ea4 # projectriff/cnab-riff master as of 2019-05-10
 
 pool:
   vmImage: 'ubuntu-16.04'

--- a/duffle.json
+++ b/duffle.json
@@ -38,6 +38,16 @@
                 "env": "NODE_PORT"
             },
             "default": "false"
+        },
+        "manifest_file": {
+            "type": "string",
+            "metadata": {
+                "description": "absolute path to the manifest file"
+            },
+            "destination": {
+                "env:": "MANIFEST_FILE"
+            },
+            "default": "/cnab/app/kab/manifest.yaml"
         }
     },
     "credentials": null

--- a/main.go
+++ b/main.go
@@ -47,18 +47,12 @@ const (
 
 func main()  {
 
-	args := os.Args[1:]
-	var path string
-	if len(args) > 0 {
-		path = args[0]
-	} else {
-		path = "/cnab/app/kab/template.yaml"
-	}
-
 	setupLogging()
 
+	path := os.Getenv("MANIFEST_FILE")
 	action := os.Getenv("CNAB_ACTION")
 	action = strings.ToLower(action)
+	log.Debugf("performing action: %s, manifest file: %s", action, path)
 	switch action {
 	case "install":
 		install(path)


### PR DESCRIPTION
define manifest path in cnab.json so that users can override it. Renamed the default declarative manifest to manifest.yaml

closes #22 